### PR TITLE
Add labextension setup

### DIFF
--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -138,6 +138,7 @@ export DASK_LABEXTENSION__FACTORY__CLASS=LocalCluster
 export DASK_LABEXTENSION__FACTORY__KWARGS__MEMORY_LIMIT=3900MB
 export DASK_LABEXTENSION__FACTORY__KWARGS__LOCAL_DIRECTORY=\\\$PBS_JOBFS/dask-worker-space
 export DASK_LABEXTENSION__DEFAULT__WORKERS=\\\$PBS_NCPUS
+export DASK_DISTRIBUTED__DASHBOARD__LINK="/proxy/{port}/status"
 
 jupyter notebook --NotebookApp.token="\\\$TOKEN" --no-browser --ip="\\\$HOSTNAME" --port "\\\$PORT" --port-retries=0
 EOQ
@@ -187,7 +188,28 @@ URL="http://localhost:${local_port}/lab?token=${token}"
 
 cat << EOF
 
-Start a Dask cluster in your notebook using the Dask panel of Jupyterlab
+Start a Dask cluster in your notebook using the Dask panel of Jupyterlab, or by
+running
+
+---------------------------------------------------------------
+import os
+import dask.distributed
+
+# Edit as desired
+threads_per_worker = 1
+
+try:
+    c # Already running
+except NameError:
+    c = dask.distributed.Client(
+        n_workers=int(os.environ['PBS_NCPUS'])//threads_per_worker,
+        threads_per_worker=threads_per_worker,
+        memory_limit=f'{3.9*threads_per_worker}gb',
+        local_directory=os.path.join(os.environ['PBS_JOBFS'],
+                                     'dask-worker-space')
+    )
+c
+---------------------------------------------------------------
 
 Opening ${URL}
 EOF

--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -30,7 +30,7 @@ set -eu
 USER=''
 PROJECT='' # Note- should be the full pbs flag '-P a12' if overriding
 LOGINNODE='gadi.nci.org.au'
-QUEUE='express'
+QUEUE='normal'
 NCPUS='1'
 MEM=''
 WALLTIME=1:00:00

--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -133,6 +133,12 @@ echo "\\\$HOSTNAME \\\$TOKEN \\\$PBS_JOBID \\\$PORT" > "\$WORKDIR/message"
 echo "runjp log dir \$WORKDIR"
 cat "\$WORKDIR/message"
 
+export DASK_LABEXTENSION__FACTORY__MODULE=dask.distributed
+export DASK_LABEXTENSION__FACTORY__CLASS=LocalCluster
+export DASK_LABEXTENSION__FACTORY__KWARGS__MEMORY_LIMIT=3900MB
+export DASK_LABEXTENSION__FACTORY__KWARGS__LOCAL_DIRECTORY=\\\$PBS_JOBFS/dask-worker-space
+export DASK_LABEXTENSION__DEFAULT__WORKERS=\\\$PBS_NCPUS
+
 jupyter notebook --NotebookApp.token="\\\$TOKEN" --no-browser --ip="\\\$HOSTNAME" --port "\\\$PORT" --port-retries=0
 EOQ
 
@@ -169,7 +175,7 @@ done
 echo "Notebook running as PBS job ${jobid}"
 echo
 echo "Starting tunnel..."
-$SSH -N -L "${local_port}:$jobhost:${remote_port}" -L "8787:$jobhost:8787" "$LOGINNODE" &
+$SSH -N -L "${local_port}:$jobhost:${remote_port}" "$LOGINNODE" &
 tunnelid=$!
 
 # Shut everything down on exit
@@ -181,27 +187,7 @@ URL="http://localhost:${local_port}/lab?token=${token}"
 
 cat << EOF
 
-Start a Dask cluster in your notebook with
-
----------------------------------------------------------------
-import os
-import dask.distributed
-
-# Edit as desired
-threads_per_worker = 1
-
-try:
-    c # Already running
-except NameError:
-    c = dask.distributed.Client(
-        n_workers=int(os.environ['PBS_NCPUS'])//threads_per_worker,
-        threads_per_worker=threads_per_worker,
-        memory_limit=f'{4*threads_per_worker}gb',
-        local_directory=os.path.join(os.environ['PBS_JOBFS'],
-                                     'dask-worker-space')
-    )
-c
----------------------------------------------------------------
+Start a Dask cluster in your notebook using the Dask panel of Jupyterlab
 
 Opening ${URL}
 EOF


### PR DESCRIPTION
Experiment adding dask-labextension, as suggested in #1 

To try out you'll need to create a conda environment, as labextension isn't installed in analysis:
```
conda create -n proxytest python=3 nodejs jupyterlab dask-labextension -c conda-forge
conda activate proxytest
jupyter labextension install dask-labextension
```
then connect to that environment using `./gadi_jupyter -e proxytest`

Things I like
- No need to forward the dask dashboard port
- Integration with the jupyterlab dashboard

Things I don't like
- Poor integration with the notebooks (there is a button to insert the connection URL, but presumably that changes each time you connect to Gadi)
- Would probably want to set up a central configuration file for most settings rather than set up dask-labextension through environment variables