### PR TITLE
Reconnect to jupyter-notebook job in gadi

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Queue Options:
     -t TIME:    Walltime limit (default 1 hour)
     -J JOBFS:   Jobfs allocation (default 100 GB)
     -P PROJ:    Submit job under project PROJ
+    -R RECONNECT: Reconnect to existing job under project PROJ
+                  (Boolean: default True)
 ```
 
 You will need to have ssh keys setup for logging into gadi. There is a 

--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -20,8 +20,8 @@ Queue Options:
     -t TIME:      Walltime limit (default 1 hour)
     -J JOBFS:     Jobfs allocation (default 100 GB)
     -P PROJ:      Submit job under project PROJ
-    -R RECONNECT: Reconnect to existing job under project PROJ (default True)
-
+    -R RECONNECT: Reconnect to existing job under project PROJ 
+                  (Boolean: default True)
 EOF
 }
 

--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -40,7 +40,7 @@ CONDA_ENV=analysis3-20.01
 RECONNECT=True
 
 # Handle arguments
-optspec="hl:L:q:n:m:t:J:P:e:"
+optspec="hl:L:q:n:m:t:J:P:e:R:"
 while getopts "$optspec" optchar; do
     case "${optchar}" in
         h)
@@ -96,8 +96,6 @@ fi
 
 SUBMITOPTS="-N jupyter-notebook ${PROJECT:+-P '$PROJECT'} -q '$QUEUE' -l 'ncpus=${NCPUS},mem=${MEM},walltime=${WALLTIME},jobfs=${JOBFS}'"
 
-echo "Starting notebook on ${LOGINNODE}..."
-
 # Check connection
 $SSH "$LOGINNODE" true
 
@@ -110,17 +108,20 @@ if $RECONNECT; then
 
 message=$(
 $SSH -q "$LOGINNODE" <<EOF | tail -n 1
+PROJECT="$PROJECT"
 # Look for processes titled jupyter-notebook. 
-processes=(\$(/g/data/hh5/public/apps/nci_scripts/uqstat -f csv  | grep jupyter-notebook | sed 's/,/\n/g'))
+processes=(\$(/g/data/hh5/public/apps/nci_scripts/uqstat -f csv  | grep jupyter-notebook | grep \$PROJECT | sed 's/,/\n/g'))
 if [[ -n \$processes ]];
 then
     set -eu
     # Count number of jupyter-notebook sessions.
     repeat=(\$( echo \${processes[@]} | tr " " "\n" | sort | uniq -c | sort -k2nr | grep jupyter-notebook | sed -e 's/^ *//g' | tr " " "\n" ))
-    # TO DO: Perhaps join all sessions or kill all processes. ATM, it wont connect.
+    # TO DO: Perhaps join all sessions or kill all processes. ATM, it will connect 
+    # to first session.
     if [[ \$repeat != "1" ]]; 
     then
         echo "There are several sessions running"; 
+        qcat \${processes[0]} | head -n 1
     else
         # Extract process information
         qcat \${processes[0]} | head -n 1
@@ -131,10 +132,14 @@ else
 fi
 EOF
 )
+else
+    message="New Job"
 fi
 
 if [[ ! $RECONNECT ]] || [[ $message == "New Job" ]]
 then
+
+echo "Starting notebook on ${LOGINNODE}..."
 
 message=$(
 $SSH -q "$LOGINNODE" <<EOF | tail -n 1
@@ -193,6 +198,8 @@ done
 cat "\$WORKDIR/message"
 EOF
 )
+else
+echo "Reconnecting to notebook on ${LOGINNODE}..."
 fi
 
 echo "Remote Message: '$message'"

--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -14,12 +14,13 @@ General Options:
     -e:         Conda environment
 
 Queue Options:
-    -q QUEUE:   Queue name
-    -n NCPU:    Use NCPU cpus
-    -m MEM:     Memory allocation (default 4*NCPU GB)
-    -t TIME:    Walltime limit (default 1 hour)
-    -J JOBFS:   Jobfs allocation (default 100 GB)
-    -P PROJ:    Submit job under project PROJ
+    -q QUEUE:     Queue name
+    -n NCPU:      Use NCPU cpus
+    -m MEM:       Memory allocation (default 4*NCPU GB)
+    -t TIME:      Walltime limit (default 1 hour)
+    -J JOBFS:     Jobfs allocation (default 100 GB)
+    -P PROJ:      Submit job under project PROJ
+    -R RECONNECT: Reconnect to existing job under project PROJ (default True)
 
 EOF
 }
@@ -36,6 +37,7 @@ MEM=''
 WALLTIME=1:00:00
 JOBFS=100gb
 CONDA_ENV=analysis3-20.01
+RECONNECT=True
 
 # Handle arguments
 optspec="hl:L:q:n:m:t:J:P:e:"
@@ -72,6 +74,8 @@ while getopts "$optspec" optchar; do
         e)
             CONDA_ENV="${OPTARG}"
             ;;
+	R)  RECONNECT="${OPTARG}"
+            ;;
         *)
             print_help
             exit 2
@@ -102,6 +106,36 @@ echo "qsub ${SUBMITOPTS}"
 # Kill the job if this top-level script is cancelled while the job is still in the queue
 trap "{ echo 'Stopping queued job... (Ctrl-C will leave job in the queue)' ; $SSH \"$LOGINNODE\" <<< \"qdel \\\$(cat \\$WORKDIR/jobid)\" ; }" EXIT
 
+if $RECONNECT; then
+
+message=$(
+$SSH -q "$LOGINNODE" <<EOF | tail -n 1
+# Look for processes titled jupyter-notebook. 
+processes=(\$(/g/data/hh5/public/apps/nci_scripts/uqstat -f csv  | grep jupyter-notebook | sed 's/,/\n/g'))
+if [[ -n \$processes ]];
+then
+    set -eu
+    # Count number of jupyter-notebook sessions.
+    repeat=(\$( echo \${processes[@]} | tr " " "\n" | sort | uniq -c | sort -k2nr | grep jupyter-notebook | sed -e 's/^ *//g' | tr " " "\n" ))
+    # TO DO: Perhaps join all sessions or kill all processes. ATM, it wont connect.
+    if [[ \$repeat != "1" ]]; 
+    then
+        echo "There are several sessions running"; 
+    else
+        # Extract process information
+        qcat \${processes[0]} | head -n 1
+    fi
+else
+    # If job doesn't exist then the message is overwritten
+    echo "New Job"
+fi
+EOF
+)
+fi
+
+if [[ ! $RECONNECT ]] || [[ $message == "New Job" ]]
+then
+
 message=$(
 $SSH -q "$LOGINNODE" <<EOF | tail -n 1
 
@@ -130,7 +164,6 @@ PORT=\\\$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.
 # Write message file with info for the local connection
 echo "\\\$HOSTNAME \\\$TOKEN \\\$PBS_JOBID \\\$PORT" > "\$WORKDIR/message"
 
-echo "runjp log dir \$WORKDIR"
 cat "\$WORKDIR/message"
 
 export DASK_LABEXTENSION__FACTORY__MODULE=dask.distributed
@@ -160,6 +193,7 @@ done
 cat "\$WORKDIR/message"
 EOF
 )
+fi
 
 echo "Remote Message: '$message'"
 


### PR DESCRIPTION
Added functionality to reconnect to an existing jupyter-notebook job in Gadi. The flag`-R` (Reconnect) allows the user to rejoin a job under a specific project after the connection is lost. 

`gadi_jupyter` flag -R options (default `True`):
- `-R True`, the function will reconnect to an existing `jupyter-notebook` session, if none exist, a new session will be created.
- `-R True -P XXX` The user can have a unique jupyter-notebook session for each of their projects. If a session exists for a given project `-P`, it will be reconnected. 
- `-R False`, the functionality remains as before, It will create a new session every time the script is executed.

This addresses the issues of internet drops or disconnecting from the job without killing it. 