### PR TITLE
Improve gadi_jupyter waiting for start

### DIFF
--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -276,15 +276,17 @@ echo "Starting tunnel..."
 if [ -n "$DEBUG" ]; then
     echo "DEBUG:" $SSH -N -L "${local_port}:$jobhost:${remote_port}" "$LOGINNODE"
 fi
-$SSH -N -L "${local_port}:$jobhost:${remote_port}" "$LOGINNODE" &
+$SSH -N -L "${local_port}:$jobhost:${remote_port}" "$LOGINNODE" &> /dev/null &
 tunnelid=$!
 
 # Shut everything down on exit
 trap "{ echo 'Closing connections... (Ctrl-C will leave job in the queue)' ; kill $tunnelid ; $SSH "$LOGINNODE" qdel $jobid ; }" EXIT
 
-# Wait for startup then open a browser
-sleep 5
 URL="http://localhost:${local_port}/lab?token=${token}"
+
+# Wait for startup then open a browser
+until curl $URL &> /dev/null; do echo -n '.'; sleep 1; done
+echo
 
 cat << EOF
 


### PR DESCRIPTION
Rather than waiting for a fixed 5 seconds before opening a browser, poll
with curl to check if jupyter lab has fully started

Also disable SSH error messages (like channel 2: open failed: connect
failed: Connection refused) by sending those to /dev/null