### PR TITLE
Change hh5 to xp65 conda

### DIFF
--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -225,7 +225,7 @@ export DASK_LABEXTENSION__DEFAULT__WORKERS=\\\$PBS_NCPUS
 export DASK_DISTRIBUTED__DASHBOARD__LINK="/proxy/{port}/status"
 export DASK_TEMPORARY_DIRECTORY="\\\$TMPDIR"
 
-$STRACE /g/data/xp65/public/apps/med_conda_scripts/analysis3-25.03.d/bin/jupyter lab --NotebookApp.token="\\\$TOKEN" --no-browser --ip="\\\$HOSTNAME" --port "\\\$PORT" --port-retries=0
+$STRACE jupyter lab --NotebookApp.token="\\\$TOKEN" --no-browser --ip="\\\$HOSTNAME" --port "\\\$PORT" --port-retries=0
 EOQ
 
 # Required for conda

--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -177,9 +177,16 @@ set -eu
 WORKDIR="$WORKDIR"
 mkdir -p "\$WORKDIR"
 
-# Check if a xp65 member
+# Check if an xp65 member
 if [ ! -d /g/data/xp65 ]; then
     echo "ERROR: \$USER is not a member of xp65. Join at https://my.nci.org.au/mancini/project/xp65/join" >&2
+    echo "x x x x ERROR"
+    exit
+fi
+
+# Check if an ik11 member
+if [ ! -d /g/data/ik11 ]; then
+    echo "ERROR: \$USER is not a member of ik11. Join at https://my.nci.org.au/mancini/project/ik11/join" >&2
     echo "x x x x ERROR"
     exit
 fi

--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -228,8 +228,8 @@ export DASK_TEMPORARY_DIRECTORY="\\\$TMPDIR"
 $STRACE jupyter lab --NotebookApp.token="\\\$TOKEN" --no-browser --ip="\\\$HOSTNAME" --port "\\\$PORT" --port-retries=0
 EOQ
 
-# Required for conda
-storage="gdata/xp65"
+# Required for conda + nci_scripts
+storage="gdata/xp65+gdata/hh5"
 
 if [ -n "$STORAGE" ]; then
     storage="$STORAGE+\$storage"

--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -177,9 +177,9 @@ set -eu
 WORKDIR="$WORKDIR"
 mkdir -p "\$WORKDIR"
 
-# Check if a hh5 member
-if [ ! -d /g/data/hh5 ]; then
-    echo "ERROR: \$USER is not a member of hh5. Join at https://my.nci.org.au/mancini/project/hh5/join" >&2
+# Check if a xp65 member
+if [ ! -d /g/data/xp65 ]; then
+    echo "ERROR: \$USER is not a member of xp65. Join at https://my.nci.org.au/mancini/project/xp65/join" >&2
     echo "x x x x ERROR"
     exit
 fi
@@ -200,8 +200,8 @@ cat > "\$WORKDIR/runjp.sh" <<EOQ
 
 module purge
 
-eval "\\\$(/g/data/hh5/public/apps/miniconda3/bin/conda shell.bash hook)"
-conda activate "${CONDA_ENV}"
+module use /g/data/xp65/public/modules
+module load conda/analysis3
 
 set -eu
 
@@ -225,11 +225,11 @@ export DASK_LABEXTENSION__DEFAULT__WORKERS=\\\$PBS_NCPUS
 export DASK_DISTRIBUTED__DASHBOARD__LINK="/proxy/{port}/status"
 export DASK_TEMPORARY_DIRECTORY="\\\$TMPDIR"
 
-$STRACE jupyter lab --NotebookApp.token="\\\$TOKEN" --no-browser --ip="\\\$HOSTNAME" --port "\\\$PORT" --port-retries=0
+$STRACE /g/data/xp65/public/apps/med_conda_scripts/analysis3-25.03.d/bin/jupyter lab --NotebookApp.token="\\\$TOKEN" --no-browser --ip="\\\$HOSTNAME" --port "\\\$PORT" --port-retries=0
 EOQ
 
 # Required for conda
-storage="gdata/hh5"
+storage="gdata/xp65"
 
 if [ -n "$STORAGE" ]; then
     storage="$STORAGE+\$storage"

--- a/gadi_jupyter
+++ b/gadi_jupyter
@@ -229,7 +229,7 @@ $STRACE jupyter lab --NotebookApp.token="\\\$TOKEN" --no-browser --ip="\\\$HOSTN
 EOQ
 
 # Required for conda + nci_scripts
-storage="gdata/xp65+gdata/hh5"
+storage="gdata/xp65+gdata/ik11"
 
 if [ -n "$STORAGE" ]; then
     storage="$STORAGE+\$storage"
@@ -334,7 +334,7 @@ fi
 set -e
 echo
 
-$SSH "$LOGINNODE" /g/data/hh5/public/apps/nci_scripts/qmonitor $jobid
+$SSH "$LOGINNODE" /g/data/ik11/nci_scripts/qmonitor $jobid
 
 # Move the cursor past the progress bars
 echo


### PR DESCRIPTION
I have updated gadi_jupyter to work with the xp65 conda environment.

I left the `$SSH "$LOGINNODE" /g/data/hh5/public/apps/nci_scripts/qmonitor $jobid` line at the end, even though it points to hh5, because I'm not sure if the nci_scripts are available elsewhere.

It now points to `/g/data/xp65/public/apps/med_conda_scripts/analysis3-25.03.d/bin/jupyter`, which is the default jupyter currently loaded from xp65. However, I am unsure if this is the right thing to do, because this is hardcoded to this version, and will not change to the latest analysis3 environment.